### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Ace/Config.purs
+++ b/src/Ace/Config.purs
@@ -15,6 +15,8 @@ import Data.Function.Uncurried (Fn2, runFn2)
 
 newtype ConfigOption a = ConfigOption String
 
+type role ConfigOption representational
+
 foreign import setImpl :: forall a. Fn2 (ConfigOption a) a (Effect Ace)
 
 set :: forall a. ConfigOption a -> a -> Effect Ace


### PR DESCRIPTION
This prevent terms of type `ConfigOption a` to be coerced to type `ConfigOption b`, unless `Coercible a b` holds. The reasoning being that options of some type can be set to terms of types with the same representation but not arbitrary types.
