### PR TITLE
Add inFront parameter to getMarkers

### DIFF
--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -12,6 +12,7 @@ import Ace.Editor as Editor
 import Ace.Ext.LanguageTools as LanguageTools
 import Ace.Ext.LanguageTools.Completer as Completer
 import Ace.KeyBinding as KeyBinding
+import Ace.Marker as Marker
 import Ace.Range as Range
 import Ace.ScrollBar as ScrollBar
 import Ace.Search as Search
@@ -20,7 +21,7 @@ import Ace.TokenIterator as TokenIterator
 import Ace.UndoManager as UndoManager
 import Data.Array.ST as AST
 import Data.Maybe (Maybe(..))
-import Data.Traversable (for_)
+import Data.Traversable (for_, traverse)
 import Effect (Effect)
 import Effect.Console (log)
 import Effect.Ref as Ref
@@ -352,6 +353,9 @@ miscTests = void do
   _ <- Session.documentToScreenColumn 0 0 session
   _ <- Session.documentToScreenRow 0 0 session
   _ <- Session.getScreenLength session
+  markers <- Session.getMarkers false session
+  markerIds <- traverse Marker.getId markers
+  log $ "markers " <> show markerIds
 
   Editor.selectMoreLines 0 editor
   Editor.setKeyboardHandler "" editor

--- a/src/Ace/EditSession.js
+++ b/src/Ace/EditSession.js
@@ -549,9 +549,9 @@ exports.createImpl = create;
 
 exports.createFromLinesImpl = create;
 
-exports.getMarkers = function (session) {
+exports.getMarkersImpl = function (inFront, session) {
   return function () {
-    var markerObj = session.getMarkers();
+    var markerObj = session.getMarkers(inFront);
     var ks = Object.getOwnPropertyNames(markerObj);
     var result = [];
     for (var i = 0; i < ks.length; i++) {

--- a/src/Ace/EditSession.purs
+++ b/src/Ace/EditSession.purs
@@ -533,6 +533,7 @@ foreign import createFromLinesImpl :: Fn2 (Array String) (Nullable String) (Effe
 createFromLines :: Array String -> Maybe String -> Effect EditSession
 createFromLines text mode' = runFn2 createFromLinesImpl text (toNullable mode')
 
+foreign import getMarkersImpl :: Fn2 Boolean EditSession (Effect (Array Marker))
 
-foreign import getMarkers
-  :: EditSession -> Effect (Array Marker)
+getMarkers :: Boolean -> EditSession -> Effect (Array Marker)
+getMarkers inFront session = runFn2 getMarkersImpl inFront session


### PR DESCRIPTION
**Description of the change**

Adds a missing `inFront` parameter to `getMarkers`. The previous FFI code omitted this parameter, which is interpreted by the JS API as a `false` default value.
https://ace.c9.io/#nav=api&api=edit_session

---

Testing this in `Example.Main`, but there are some other unrelated failures with that code. Suspecting a bundling issue that should be revisited once ES modules are available. Will take this PR out of draft mode at that time.

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
