### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+Added `purs-tidy` formatter (#44 by @thomashoneyman)
 
 ## [v8.0.0](https://github.com/purescript-contrib/purescript-ace/releases/tag/v8.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
-Added `purs-tidy` formatter (#44 by @thomashoneyman)
+- Added `purs-tidy` formatter (#44 by @thomashoneyman)
 
 ## [v8.0.0](https://github.com/purescript-contrib/purescript-ace/releases/tag/v8.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
-- Added `purs-tidy` formatter (#44 by @thomashoneyman)
+- Added `purs-tidy` formatter (#45 by @thomashoneyman)
 
 ## [v8.0.0](https://github.com/purescript-contrib/purescript-ace/releases/tag/v8.0.0) - 2021-02-26
 

--- a/src/Ace/EditSession.purs
+++ b/src/Ace/EditSession.purs
@@ -533,6 +533,5 @@ foreign import createFromLinesImpl :: Fn2 (Array String) (Nullable String) (Effe
 createFromLines :: Array String -> Maybe String -> Effect EditSession
 createFromLines text mode' = runFn2 createFromLinesImpl text (toNullable mode')
 
-
 foreign import getMarkers
   :: EditSession -> Effect (Array Marker)

--- a/src/Ace/Editor.purs
+++ b/src/Ace/Editor.purs
@@ -143,17 +143,23 @@ foreign import onImpl
 
 onBlur
   :: forall a
-   . Editor -> (Effect a) -> Effect Unit
+   . Editor
+  -> (Effect a)
+  -> Effect Unit
 onBlur self fn = runFn3 onImpl "blur" (\_ -> fn) self
 
 onFocus
   :: forall a
-   . Editor -> (Effect a) -> Effect Unit
+   . Editor
+  -> (Effect a)
+  -> Effect Unit
 onFocus self fn = runFn3 onImpl "focus" (\_ -> fn) self
 
 onCopy
   :: forall a
-   . Editor -> (String -> Effect a) -> Effect Unit
+   . Editor
+  -> (String -> Effect a)
+  -> Effect Unit
 onCopy self fn = runFn3 onImpl "copy" fn self
 
 onPaste
@@ -174,8 +180,9 @@ setPasteEventText text e = runFn2 setPasteEventTextImpl text e
 
 onChangeSession
   :: Editor
-  -> ({ oldSession :: EditSession, session :: EditSession }
-     -> Effect Unit)
+  -> ( { oldSession :: EditSession, session :: EditSession }
+       -> Effect Unit
+     )
   -> Effect Unit
 onChangeSession self fn = runFn3 onImpl "changeSession" fn self
 
@@ -600,7 +607,9 @@ foreign import findNextImpl
   :: Fn3 (Nullable SearchOptions) (Nullable Boolean) Editor (Effect Unit)
 
 findNext
-  :: Maybe SearchOptions -> Maybe Boolean -> Editor
+  :: Maybe SearchOptions
+  -> Maybe Boolean
+  -> Editor
   -> Effect Unit
 findNext options animate self =
   runFn3 findNextImpl (toNullable options) (toNullable animate) self
@@ -609,7 +618,9 @@ foreign import findPreviousImpl
   :: Fn3 (Nullable SearchOptions) (Nullable Boolean) Editor (Effect Unit)
 
 findPrevious
-  :: Maybe SearchOptions -> Maybe Boolean -> Editor
+  :: Maybe SearchOptions
+  -> Maybe Boolean
+  -> Editor
   -> Effect Unit
 findPrevious options animate self =
   runFn3 findPreviousImpl (toNullable options) (toNullable animate) self
@@ -624,21 +635,22 @@ foreign import createImpl
   :: Fn2 VirtualRenderer (Nullable EditSession) (Effect Editor)
 
 create
-  :: VirtualRenderer -> Maybe EditSession
+  :: VirtualRenderer
+  -> Maybe EditSession
   -> Effect Editor
 create renderer session = runFn2 createImpl renderer (toNullable session)
 
 foreign import setOption
   :: forall a. String -> a -> Editor -> Effect Unit
 
-setMinLines :: Int -> Editor ->  Effect Unit
+setMinLines :: Int -> Editor -> Effect Unit
 setMinLines = setOption "minLines"
 
-setMaxLines :: Int -> Editor ->  Effect Unit
+setMaxLines :: Int -> Editor -> Effect Unit
 setMaxLines = setOption "maxLines"
 
 setAutoScrollEditorIntoView
-  :: Boolean -> Editor ->  Effect Unit
+  :: Boolean -> Editor -> Effect Unit
 setAutoScrollEditorIntoView = setOption "autoScrollEditorIntoView"
 
 setEnableBasicAutocompletion
@@ -652,7 +664,6 @@ setEnableLiveAutocompletion = setOption "enableLiveAutocompletion"
 setEnableSnippets
   :: Boolean -> Editor -> Effect Unit
 setEnableSnippets = setOption "enableSnippets"
-
 
 foreign import getKeyBinding
   :: Editor -> Effect KeyBinding

--- a/src/Ace/Ext/LanguageTools/Completer.purs
+++ b/src/Ace/Ext/LanguageTools/Completer.purs
@@ -15,10 +15,9 @@ type CompleterCallback = Maybe (Array Completion) -> Effect Unit
 foreign import mkCompleterImpl
   :: forall a
    . Fn3 (Editor -> EditSession -> Position -> String -> CompleterCallback -> Effect Unit)
-         (Maybe a -> Boolean)
-         (Maybe a -> a)
-         (Effect Completer)
-
+       (Maybe a -> Boolean)
+       (Maybe a -> a)
+       (Effect Completer)
 
 mkCompleter
   :: (Editor -> EditSession -> Position -> String -> CompleterCallback -> Effect Unit)

--- a/src/Ace/KeyBinding.purs
+++ b/src/Ace/KeyBinding.purs
@@ -10,7 +10,8 @@ import Partial.Unsafe (unsafePartial)
 import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 
 type KeyboardHandler
-  = { editor :: Editor }
+  =
+  { editor :: Editor }
   -> Int
   -> String
   -> Int

--- a/src/Ace/Marker.purs
+++ b/src/Ace/Marker.purs
@@ -16,7 +16,10 @@ foreign import getInFront :: Marker -> Effect Boolean
 foreign import getType :: Marker -> Effect String
 foreign import getRangeImpl
   :: forall a
-   . Maybe a -> (a -> Maybe a) -> Marker -> Effect (Maybe Range)
+   . Maybe a
+  -> (a -> Maybe a)
+  -> Marker
+  -> Effect (Maybe Range)
 
 getRange :: Marker -> Effect (Maybe Range)
 getRange = getRangeImpl Nothing Just

--- a/src/Ace/Types.purs
+++ b/src/Ace/Types.purs
@@ -79,10 +79,10 @@ readPosition e = do
   pure $ Position { row, column }
 
 getRow :: Position -> Int
-getRow (Position {row : row}) = row
+getRow (Position { row: row }) = row
 
 getColumn :: Position -> Int
-getColumn (Position {column : column}) = column
+getColumn (Position { column: column }) = column
 
 type TokenInfo =
   { value :: String


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.  the tool is not an official `core` or `contrib` project, it was built and is maintained by members of the PureScript core team and it isn't a library dependency, so if there are ever issues with the tool it won't block maintenance or release on these libraries.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
