### PR TITLE
Add two extra exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+* Added bindings for the options `navigateWithinSoftTabs` and `placeholder`.
+
 Bugfixes:
 
 Other improvements:

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.4-20230105/src/packages.dhall
 
 in  upstream

--- a/src/Ace/Editor.purs
+++ b/src/Ace/Editor.purs
@@ -125,6 +125,8 @@ module Ace.Editor
   , setEnableLiveAutocompletion
   , setEnableBasicAutocompletion
   , setEnableSnippets
+  , setNavigateWithinSoftTabs
+  , setPlaceholder
   , getKeyBinding
   ) where
 
@@ -664,6 +666,14 @@ setEnableLiveAutocompletion = setOption "enableLiveAutocompletion"
 setEnableSnippets
   :: Boolean -> Editor -> Effect Unit
 setEnableSnippets = setOption "enableSnippets"
+
+setNavigateWithinSoftTabs
+  :: Boolean -> Editor -> Effect Unit
+setNavigateWithinSoftTabs = setOption "navigateWithinSoftTabs"
+
+setPlaceholder
+  :: String -> Editor -> Effect Unit
+setPlaceholder = setOption "placeholder"
 
 foreign import getKeyBinding
   :: Editor -> Effect KeyBinding


### PR DESCRIPTION
**Description of the change**
Thanks for these useful bindings! This is a small ad-hoc PR to add support for two missing options:

 - `navigateWithinSoftTabs` is mentioned on https://github.com/ajaxorg/ace/wiki/Configuring-Ace
 - `placeholder` is for some reason not mentioned there, but it is in the [API docs](https://ajaxorg.github.io/ace-api-docs/interfaces/Ace.EditorOptions.html#placeholder).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
